### PR TITLE
fix: point market data to alphavantage host

### DIFF
--- a/apps/api/trader-assistant/trading-dashboard/ENV.example
+++ b/apps/api/trader-assistant/trading-dashboard/ENV.example
@@ -7,6 +7,7 @@ POSTGRES_PASSWORD=changeme
 SPRING_PROFILES_ACTIVE=dev
 
 # API Keys
+TRADING_MARKETDATA_BASE_URL=https://www.alphavantage.co
 MARKETDATA_API_KEY=replace_me
 ALPHA_VANTAGE_API_KEY=replace_me
 YAHOO_FINANCE_API_KEY=replace_me

--- a/apps/api/trader-assistant/trading-dashboard/src/main/resources/application.yml
+++ b/apps/api/trader-assistant/trading-dashboard/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 trading:
   marketdata:
-    base-url: https://api.alpha-vantage.co
+    base-url: https://www.alphavantage.co
     api-key: ${MARKETDATA_API_KEY:${ALPHA_VANTAGE_API_KEY}}
     health-symbol: ${MARKETDATA_HEALTH_SYMBOL:SPY}
     health-cache-ttl: ${MARKETDATA_HEALTH_CACHE_TTL:PT1M}


### PR DESCRIPTION
## Summary
- point the default trading market data endpoint at the canonical alphavantage host
- surface the corresponding environment variable in ENV.example so operators inherit the new default

## Testing
- ./gradlew --console=plain test --tests RealMarketDataProviderTest

------
https://chatgpt.com/codex/tasks/task_e_68d20a1a539c8326bbdb6cfc817d284e