### PR TITLE
feat: include quote timestamp in api contract

### DIFF
--- a/apps/api/trader-assistant/trading-dashboard/openAPI.yaml
+++ b/apps/api/trader-assistant/trading-dashboard/openAPI.yaml
@@ -31,9 +31,13 @@ components:
       required:
         - symbol
         - price
+        - timestamp
       properties:
         symbol:
           type: string
         price:
           type: number
           format: double
+        timestamp:
+          type: string
+          format: date-time

--- a/apps/api/trader-assistant/trading-dashboard/src/test/java/com/austinharlan/trading_dashboard/controllers/QueueControllerIT.java
+++ b/apps/api/trader-assistant/trading-dashboard/src/test/java/com/austinharlan/trading_dashboard/controllers/QueueControllerIT.java
@@ -25,11 +25,13 @@ class QuoteControllerIT {
 
   @Test
   void getsQuote() throws Exception {
+    Instant timestamp = Instant.parse("2024-01-01T00:00:00Z");
     when(quoteService.getCached("UUUU"))
-        .thenReturn(new Quote("UUUU", BigDecimal.valueOf(100.00), Instant.now()));
+        .thenReturn(new Quote("UUUU", BigDecimal.valueOf(100.00), timestamp));
 
     mvc.perform(get("/api/quotes/UUUU"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.symbol").value("UUUU"));
+        .andExpect(jsonPath("$.symbol").value("UUUU"))
+        .andExpect(jsonPath("$.timestamp").value(timestamp.toString()));
   }
 }

--- a/apps/api/trader-assistant/trading-dashboard/src/test/java/com/austinharlan/trading_dashboard/controllers/QuoteControllerTest.java
+++ b/apps/api/trader-assistant/trading-dashboard/src/test/java/com/austinharlan/trading_dashboard/controllers/QuoteControllerTest.java
@@ -26,11 +26,13 @@ class QuoteControllerTest {
 
   @Test
   void getQuote_returnsJson() throws Exception {
+    Instant timestamp = Instant.parse("2024-01-01T00:00:00Z");
     when(quoteService.getCached("UUUU"))
-        .thenReturn(new Quote("UUUU", BigDecimal.valueOf(100.00), Instant.now()));
+        .thenReturn(new Quote("UUUU", BigDecimal.valueOf(100.00), timestamp));
 
     mvc.perform(get("/api/quotes/UUUU"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.symbol", is("UUUU")));
+        .andExpect(jsonPath("$.symbol", is("UUUU")))
+        .andExpect(jsonPath("$.timestamp", is(timestamp.toString())));
   }
 }


### PR DESCRIPTION
## Summary
- declare the quote timestamp field in the OpenAPI schema
- exercise the generated timestamp contract in controller unit and integration tests

## Testing
- ./gradlew openApiGenerate --no-daemon
- ./gradlew test --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d211cb55f88326b00cd7b47aad30a3