### PR TITLE
fix: Postgres-compatible V6 migration syntax

### DIFF
--- a/apps/api/trader-assistant/trading-dashboard/src/main/resources/db/migration/V6__options_support.sql
+++ b/apps/api/trader-assistant/trading-dashboard/src/main/resources/db/migration/V6__options_support.sql
@@ -9,10 +9,10 @@ ALTER TABLE trades ADD COLUMN expiration_date DATE;
 ALTER TABLE trades ADD COLUMN multiplier INTEGER NOT NULL DEFAULT 1;
 ALTER TABLE trades ADD COLUMN linked_trade_id BIGINT;
 
--- 2. Expand side constraint: drop old, add new
--- The V4 inline CHECK is unnamed in H2 but named in Postgres.
--- Use a column redefine approach that works in both:
-ALTER TABLE trades ALTER COLUMN side VARCHAR(8) NOT NULL;
+-- 2. Expand side column to fit 'EXERCISE' (8 chars)
+-- Drop the V4 inline CHECK first (Postgres auto-names it trades_side_check)
+ALTER TABLE trades DROP CONSTRAINT IF EXISTS trades_side_check;
+ALTER TABLE trades ALTER COLUMN side TYPE VARCHAR(8);
 
 -- 3. Add new constraints
 ALTER TABLE trades ADD CONSTRAINT trades_asset_type_check


### PR DESCRIPTION
## Summary

- Fix `ALTER TABLE trades ALTER COLUMN side VARCHAR(8) NOT NULL` → `ALTER COLUMN side TYPE VARCHAR(8)` (H2-only syntax doesn't work in Postgres)
- Drop V4 inline CHECK constraint explicitly before widening column

Fixes 33 integration test failures in CI from #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)