### PR TITLE
fix: relax price constraint for EXPIRE trades, handle validation errors

### DIFF
--- a/apps/api/trader-assistant/trading-dashboard/src/main/java/com/austinharlan/trading_dashboard/controllers/ApiExceptionHandler.java
+++ b/apps/api/trader-assistant/trading-dashboard/src/main/java/com/austinharlan/trading_dashboard/controllers/ApiExceptionHandler.java
@@ -67,6 +67,11 @@ class ApiExceptionHandler {
         HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", summary, fieldErrors.toArray(new String[0]));
   }
 
+  @ExceptionHandler(IllegalArgumentException.class)
+  ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
+    return build(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", ex.getMessage());
+  }
+
   @ExceptionHandler(HttpMessageNotReadableException.class)
   ResponseEntity<ErrorResponse> handleUnreadableBody(HttpMessageNotReadableException ex) {
     return build(

--- a/apps/api/trader-assistant/trading-dashboard/src/main/resources/db/migration/V7__relax_price_for_expire.sql
+++ b/apps/api/trader-assistant/trading-dashboard/src/main/resources/db/migration/V7__relax_price_for_expire.sql
@@ -1,0 +1,9 @@
+-- V7__relax_price_for_expire.sql
+-- Allow price_per_share = 0 for EXPIRE/EXERCISE trades
+
+-- Drop the V4 inline CHECK (Postgres auto-names it trades_price_per_share_check)
+ALTER TABLE trades DROP CONSTRAINT IF EXISTS trades_price_per_share_check;
+
+-- Re-add with >= 0 instead of > 0
+ALTER TABLE trades ADD CONSTRAINT trades_price_per_share_check
+    CHECK (price_per_share >= 0);


### PR DESCRIPTION
## Summary
- **V7 migration**: Relaxes `price_per_share` CHECK from `> 0` to `>= 0` — EXPIRE/EXERCISE trades legitimately use $0 price
- **ApiExceptionHandler**: Adds `IllegalArgumentException` → 400 handler so validation errors (e.g., EXPIRE on equity) return proper 400 instead of 500

Fixes 7 CI test failures: 3 DemoIT, 3 DemoServiceIT (cascading from EXPIRE seed data violating constraint), 1 TradeIT (expected 400 got 500).

## Test plan
- [ ] CI integration tests pass (DemoIT, DemoServiceIT, TradeIT)
- [ ] All 114 tests green